### PR TITLE
Inherit doc, #5

### DIFF
--- a/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
@@ -20,13 +20,6 @@ namespace PullThroughDoc.Test
 		public void BaseClass_Documentation_PullsThrough()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -40,16 +33,9 @@ namespace PullThroughDoc.Test
         }
     }";
 
-			ExpectPullThroughDiagnosticAt(test, "DoThing", 18, 27);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 11, 27);
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -71,13 +57,6 @@ namespace PullThroughDoc.Test
 		public void BaseClass_GetSetProperty_DocumentationPulledThrough()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -91,16 +70,9 @@ namespace PullThroughDoc.Test
         }
     }";
 
-			ExpectPullThroughDiagnosticAt(test, "GetsThing", 18, 27);
+			ExpectPullThroughDiagnosticAt(test, "GetsThing", 11, 27);
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -121,13 +93,6 @@ namespace PullThroughDoc.Test
 		public void BaseClass_GetterOnlyProperty_DocumentationPulledThrough()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -140,16 +105,9 @@ namespace PullThroughDoc.Test
 			public override string GetsThing { get => null; }
         }
     }";
-            ExpectPullThroughDiagnosticAt(test, "GetsThing", 18, 27);
+            ExpectPullThroughDiagnosticAt(test, "GetsThing", 11, 27);
 
             var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -170,13 +128,6 @@ namespace PullThroughDoc.Test
         public void ChangeToSummary_Works()
         {
             var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -192,13 +143,6 @@ namespace PullThroughDoc.Test
     }";
 
             var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -220,13 +164,6 @@ namespace PullThroughDoc.Test
         public void ChangeToSummary_MultipleLineBreaks_Works()
         {
             var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -244,13 +181,6 @@ namespace PullThroughDoc.Test
     }";
 
             var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -273,13 +203,6 @@ namespace PullThroughDoc.Test
         public void ChangeToSummary_MultipleLineSummary_Works()
         {
             var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -297,13 +220,6 @@ namespace PullThroughDoc.Test
     }";
 
             var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 

--- a/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using TestHelper;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PullThroughDoc.Test
 {
@@ -11,6 +8,12 @@ namespace PullThroughDoc.Test
 	[TestClass]
 	public class BaseClassDocumentationTests : PullThroughDocCodeFixVerifier
 	{
+
+        [TestInitialize]
+        public void Init()
+		{
+            CodeFixProvider = new PullThroughDocCodeFixProvider();
+		}
 
 
 		[TestMethod]
@@ -162,5 +165,163 @@ namespace PullThroughDoc.Test
     }";
 			VerifyCSharpFix(test, fixtest);
 		}
-	}
+
+        [TestMethod]
+        public void ChangeToSummary_Works()
+        {
+            var test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Gets A Thing </summary>
+			public virtual string GetsThing { get => null; }
+		}
+        class TypeName : BaseClass
+        {
+            /// <inheritdocs />
+			public override string GetsThing { get => null; }
+        }
+    }";
+
+            var fixtest = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Gets A Thing </summary>
+			public virtual string GetsThing { get => null; }
+		}
+        class TypeName : BaseClass
+        {
+			/// <summary>Gets A Thing </summary>
+			public override string GetsThing { get => null; }
+        }
+    }";
+            VerifyCSharpFix(test, fixtest);
+        }
+
+
+        [TestMethod]
+        public void ChangeToSummary_MultipleLineBreaks_Works()
+        {
+            var test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Gets A Thing </summary>
+			public virtual string GetsThing { get => null; }
+		}
+        class TypeName : BaseClass
+        {
+
+
+            /// <inheritdocs />
+			public override string GetsThing { get => null; }
+        }
+    }";
+
+            var fixtest = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Gets A Thing </summary>
+			public virtual string GetsThing { get => null; }
+		}
+        class TypeName : BaseClass
+        {
+
+
+			/// <summary>Gets A Thing </summary>
+			public override string GetsThing { get => null; }
+        }
+    }";
+            VerifyCSharpFix(test, fixtest);
+        }
+
+        [TestMethod]
+        public void ChangeToSummary_MultipleLineSummary_Works()
+        {
+            var test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>
+            /// Gets A Thing
+            /// </summary>
+			public virtual string GetsThing { get => null; }
+		}
+        class TypeName : BaseClass
+        {
+            /// <inheritdocs />
+			public override string GetsThing { get => null; }
+        }
+    }";
+
+            var fixtest = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>
+            /// Gets A Thing
+            /// </summary>
+			public virtual string GetsThing { get => null; }
+		}
+        class TypeName : BaseClass
+        {
+			/// <summary>
+            /// Gets A Thing
+            /// </summary>
+			public override string GetsThing { get => null; }
+        }
+    }";
+            VerifyCSharpFix(test, fixtest);
+        }
+    }
 }

--- a/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
@@ -12,6 +12,7 @@ namespace PullThroughDoc.Test
 	public class BaseClassDocumentationTests : PullThroughDocCodeFixVerifier
 	{
 
+
 		[TestMethod]
 		public void BaseClass_Documentation_PullsThrough()
 		{
@@ -35,18 +36,8 @@ namespace PullThroughDoc.Test
 			public override string DoThing() {}
         }
     }";
-			var expected = new DiagnosticResult
-			{
-				Id = "PullThroughDoc",
-				Message = String.Format("Pull through documentation for {0}.", "DoThing"),
-				Severity = DiagnosticSeverity.Info,
-				Locations =
-					new[] {
-							new DiagnosticResultLocation("Test0.cs", 18, 27)
-						}
-			};
 
-			VerifyCSharpDiagnostic(test, expected);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 18, 27);
 
 			var fixtest = @"
     using System;
@@ -96,18 +87,8 @@ namespace PullThroughDoc.Test
 			public override string GetsThing { get; set; }
         }
     }";
-			var expected = new DiagnosticResult
-			{
-				Id = "PullThroughDoc",
-				Message = String.Format("Pull through documentation for {0}.", "GetsThing"),
-				Severity = DiagnosticSeverity.Info,
-				Locations =
-					new[] {
-							new DiagnosticResultLocation("Test0.cs", 18, 27)
-						}
-			};
 
-			VerifyCSharpDiagnostic(test, expected);
+			ExpectPullThroughDiagnosticAt(test, "GetsThing", 18, 27);
 
 			var fixtest = @"
     using System;
@@ -156,20 +137,9 @@ namespace PullThroughDoc.Test
 			public override string GetsThing { get => null; }
         }
     }";
-			var expected = new DiagnosticResult
-			{
-				Id = "PullThroughDoc",
-				Message = String.Format("Pull through documentation for {0}.", "GetsThing"),
-				Severity = DiagnosticSeverity.Info,
-				Locations =
-					new[] {
-							new DiagnosticResultLocation("Test0.cs", 18, 27)
-						}
-			};
+            ExpectPullThroughDiagnosticAt(test, "GetsThing", 18, 27);
 
-			VerifyCSharpDiagnostic(test, expected);
-
-			var fixtest = @"
+            var fixtest = @"
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -192,7 +162,5 @@ namespace PullThroughDoc.Test
     }";
 			VerifyCSharpFix(test, fixtest);
 		}
-
-
 	}
 }

--- a/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/BaseClassDocumentationTests.cs
@@ -101,7 +101,7 @@ namespace PullThroughDoc.Test
 			public virtual string GetsThing { get => null; }
 		}
         class TypeName : BaseClass
-        {   
+        {
 			public override string GetsThing { get => null; }
         }
     }";
@@ -116,7 +116,7 @@ namespace PullThroughDoc.Test
 			public virtual string GetsThing { get => null; }
 		}
         class TypeName : BaseClass
-        {   
+        {
 			/// <summary>Gets A Thing </summary>
 			public override string GetsThing { get => null; }
         }
@@ -128,34 +128,34 @@ namespace PullThroughDoc.Test
         public void ChangeToSummary_Works()
         {
             var test = @"
-    namespace ConsoleApplication1
+namespace ConsoleApplication1
+{
+	class BaseClass 
+	{
+		/// <summary>Gets A Thing </summary>
+		public virtual string GetsThing { get => null; }
+	}
+    class TypeName : BaseClass
     {
-		class BaseClass 
-		{
-			/// <summary>Gets A Thing </summary>
-			public virtual string GetsThing { get => null; }
-		}
-        class TypeName : BaseClass
-        {
-            /// <inheritdocs />
-			public override string GetsThing { get => null; }
-        }
-    }";
+		/// <inheritdocs />
+		public override string GetsThing { get => null; }
+    }
+}";
 
             var fixtest = @"
-    namespace ConsoleApplication1
+namespace ConsoleApplication1
+{
+	class BaseClass 
+	{
+		/// <summary>Gets A Thing </summary>
+		public virtual string GetsThing { get => null; }
+	}
+    class TypeName : BaseClass
     {
-		class BaseClass 
-		{
-			/// <summary>Gets A Thing </summary>
-			public virtual string GetsThing { get => null; }
-		}
-        class TypeName : BaseClass
-        {
-			/// <summary>Gets A Thing </summary>
-			public override string GetsThing { get => null; }
-        }
-    }";
+		/// <summary>Gets A Thing </summary>
+		public override string GetsThing { get => null; }
+    }
+}";
             VerifyCSharpFix(test, fixtest);
         }
 
@@ -164,38 +164,38 @@ namespace PullThroughDoc.Test
         public void ChangeToSummary_MultipleLineBreaks_Works()
         {
             var test = @"
-    namespace ConsoleApplication1
+namespace ConsoleApplication1
+{
+	class BaseClass 
+	{
+		/// <summary>Gets A Thing </summary>
+		public virtual string GetsThing { get => null; }
+	}
+    class TypeName : BaseClass
     {
-		class BaseClass 
-		{
-			/// <summary>Gets A Thing </summary>
-			public virtual string GetsThing { get => null; }
-		}
-        class TypeName : BaseClass
-        {
 
 
-            /// <inheritdocs />
-			public override string GetsThing { get => null; }
-        }
-    }";
+		/// <inheritdocs />
+		public override string GetsThing { get => null; }
+    }
+}";
 
             var fixtest = @"
-    namespace ConsoleApplication1
+namespace ConsoleApplication1
+{
+	class BaseClass 
+	{
+		/// <summary>Gets A Thing </summary>
+		public virtual string GetsThing { get => null; }
+	}
+    class TypeName : BaseClass
     {
-		class BaseClass 
-		{
-			/// <summary>Gets A Thing </summary>
-			public virtual string GetsThing { get => null; }
-		}
-        class TypeName : BaseClass
-        {
 
 
-			/// <summary>Gets A Thing </summary>
-			public override string GetsThing { get => null; }
-        }
-    }";
+		/// <summary>Gets A Thing </summary>
+		public override string GetsThing { get => null; }
+    }
+}";
             VerifyCSharpFix(test, fixtest);
         }
 
@@ -203,40 +203,40 @@ namespace PullThroughDoc.Test
         public void ChangeToSummary_MultipleLineSummary_Works()
         {
             var test = @"
-    namespace ConsoleApplication1
+namespace ConsoleApplication1
+{
+	class BaseClass 
+	{
+		/// <summary>
+        /// Gets A Thing
+        /// </summary>
+		public virtual string GetsThing { get => null; }
+	}
+    class TypeName : BaseClass
     {
-		class BaseClass 
-		{
-			/// <summary>
-            /// Gets A Thing
-            /// </summary>
-			public virtual string GetsThing { get => null; }
-		}
-        class TypeName : BaseClass
-        {
-            /// <inheritdocs />
-			public override string GetsThing { get => null; }
-        }
-    }";
+		/// <inheritdocs />
+		public override string GetsThing { get => null; }
+    }
+}";
 
             var fixtest = @"
-    namespace ConsoleApplication1
+namespace ConsoleApplication1
+{
+	class BaseClass 
+	{
+		/// <summary>
+        /// Gets A Thing
+        /// </summary>
+		public virtual string GetsThing { get => null; }
+	}
+    class TypeName : BaseClass
     {
-		class BaseClass 
-		{
-			/// <summary>
-            /// Gets A Thing
-            /// </summary>
-			public virtual string GetsThing { get => null; }
-		}
-        class TypeName : BaseClass
-        {
-			/// <summary>
-            /// Gets A Thing
-            /// </summary>
-			public override string GetsThing { get => null; }
-        }
-    }";
+		/// <summary>
+        /// Gets A Thing
+        /// </summary>
+		public override string GetsThing { get => null; }
+    }
+}";
             VerifyCSharpFix(test, fixtest);
         }
     }

--- a/PullThroughDoc/PullThroughDoc.Test/GeneralTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/GeneralTests.cs
@@ -24,13 +24,6 @@ namespace PullThroughDoc.Test
 		public void BaseObjectMethodOverride_NoAnalyzer()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
         class TypeName 
@@ -46,13 +39,6 @@ namespace PullThroughDoc.Test
 		public void Regions_Documentation_ExcludingRegion()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -67,16 +53,9 @@ namespace PullThroughDoc.Test
 			public override string DoThing() {}
         }
     }";
-			ExpectPullThroughDiagnosticAt(test, "DoThing", 20, 27);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 13, 27);
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 

--- a/PullThroughDoc/PullThroughDoc.Test/GeneralTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/GeneralTests.cs
@@ -1,13 +1,15 @@
-using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using TestHelper;
 
 namespace PullThroughDoc.Test
 {
 	[TestClass]
 	public class GeneralTests : PullThroughDocCodeFixVerifier
 	{
+		[TestInitialize]
+		public void Init()
+		{
+			CodeFixProvider = new PullThroughDocCodeFixProvider();
+		}
 
 		//No diagnostics expected to show up
 		[TestMethod]

--- a/PullThroughDoc/PullThroughDoc.Test/GeneralTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/GeneralTests.cs
@@ -65,18 +65,7 @@ namespace PullThroughDoc.Test
 			public override string DoThing() {}
         }
     }";
-			var expected = new DiagnosticResult
-			{
-				Id = "PullThroughDoc",
-				Message = String.Format("Pull through documentation for {0}.", "DoThing"),
-				Severity = DiagnosticSeverity.Info,
-				Locations =
-					new[] {
-							new DiagnosticResultLocation("Test0.cs", 20, 27)
-						}
-			};
-
-			VerifyCSharpDiagnostic(test, expected);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 20, 27);
 
 			var fixtest = @"
     using System;

--- a/PullThroughDoc/PullThroughDoc.Test/InheritDocTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/InheritDocTests.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PullThroughDoc.Test
 {
@@ -16,13 +15,6 @@ namespace PullThroughDoc.Test
 		public void BaseClass_WithExtraSpace_AddsInhertiDoc()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -36,16 +28,9 @@ namespace PullThroughDoc.Test
 			public override string DoThing() {}
         }
     }";
-			ExpectPullThroughDiagnosticAt(test, "DoThing", 19, 27);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 12, 27);
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -67,13 +52,6 @@ namespace PullThroughDoc.Test
 		public void BaseClass_NowLineBreakAfterBrace_AddsInhertiDoc()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -86,16 +64,9 @@ namespace PullThroughDoc.Test
 			public override string DoThing() {}
         }
     }";
-			ExpectPullThroughDiagnosticAt(test, "DoThing", 18, 27);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 11, 27);
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -116,13 +87,6 @@ namespace PullThroughDoc.Test
 		public void SwapToInherit_AddsInhertiDoc()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -138,13 +102,6 @@ namespace PullThroughDoc.Test
     }";
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -165,13 +122,6 @@ namespace PullThroughDoc.Test
         public void SwapToInherit_MultipleLineBreaks_AddsInhertiDoc()
         {
             var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -189,13 +139,6 @@ namespace PullThroughDoc.Test
     }";
 
             var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -218,13 +161,6 @@ namespace PullThroughDoc.Test
         public void SwapToInherit_MultipleLineSummary_AddsInhertiDoc()
         {
             var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 
@@ -242,13 +178,6 @@ namespace PullThroughDoc.Test
     }";
 
             var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		class BaseClass 

--- a/PullThroughDoc/PullThroughDoc.Test/InheritDocTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/InheritDocTests.cs
@@ -10,7 +10,7 @@ namespace PullThroughDoc.Test
 	public class InheritDocTests : PullThroughDocCodeFixVerifier
 	{
 		[TestMethod]
-		public void BaseClass_AddsInhertiDoc()
+		public void BaseClass_WithExtraSpace_AddsInhertiDoc()
 		{
 			var test = @"
     using System;
@@ -28,13 +28,75 @@ namespace PullThroughDoc.Test
 			public virtual string DoThing() { }
 		}
         class TypeName : BaseClass
-        {   
+        {
+
 			public override string DoThing() {}
         }
     }";
 			var expected = new DiagnosticResult
 			{
-				Id = "PullThroughDoc",
+				Id = PullThroughDocAnalyzer.PullThroughDocDiagId,
+				Message = String.Format("Pull through documentation for {0}.", "DoThing"),
+				Severity = DiagnosticSeverity.Info,
+				Locations =
+					new[] {
+							new DiagnosticResultLocation("Test0.cs", 19, 27)
+						}
+			};
+
+			VerifyCSharpDiagnostic(test, expected);
+
+			var fixtest = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Does A Thing </summary>
+			public virtual string DoThing() { }
+		}
+        class TypeName : BaseClass
+        {
+
+			/// <inheritdoc/>
+			public override string DoThing() {}
+        }
+    }";
+			VerifyCSharpFix(test, fixtest);
+		}
+
+		[TestMethod]
+		public void BaseClass_NowLineBreakAfterBrace_AddsInhertiDoc()
+		{
+			var test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Does A Thing </summary>
+			public virtual string DoThing() { }
+		}
+        class TypeName : BaseClass
+        {
+			public override string DoThing() {}
+        }
+    }";
+			var expected = new DiagnosticResult
+			{
+				Id = PullThroughDocAnalyzer.PullThroughDocDiagId,
 				Message = String.Format("Pull through documentation for {0}.", "DoThing"),
 				Severity = DiagnosticSeverity.Info,
 				Locations =
@@ -61,13 +123,15 @@ namespace PullThroughDoc.Test
 			public virtual string DoThing() { }
 		}
         class TypeName : BaseClass
-        {   
+        {
 			/// <inheritdoc/>
 			public override string DoThing() {}
         }
     }";
 			VerifyCSharpFix(test, fixtest);
 		}
+
+
 
 		protected override CodeFixProvider GetCSharpCodeFixProvider()
 		{

--- a/PullThroughDoc/PullThroughDoc.Test/InheritDocTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/InheritDocTests.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using TestHelper;
+
+namespace PullThroughDoc.Test
+{
+	[TestClass]
+	public class InheritDocTests : PullThroughDocCodeFixVerifier
+	{
+		[TestMethod]
+		public void BaseClass_AddsInhertiDoc()
+		{
+			var test = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Does A Thing </summary>
+			public virtual string DoThing() { }
+		}
+        class TypeName : BaseClass
+        {   
+			public override string DoThing() {}
+        }
+    }";
+			var expected = new DiagnosticResult
+			{
+				Id = "PullThroughDoc",
+				Message = String.Format("Pull through documentation for {0}.", "DoThing"),
+				Severity = DiagnosticSeverity.Info,
+				Locations =
+					new[] {
+							new DiagnosticResultLocation("Test0.cs", 18, 27)
+						}
+			};
+
+			VerifyCSharpDiagnostic(test, expected);
+
+			var fixtest = @"
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Diagnostics;
+
+    namespace ConsoleApplication1
+    {
+		class BaseClass 
+		{
+			/// <summary>Does A Thing </summary>
+			public virtual string DoThing() { }
+		}
+        class TypeName : BaseClass
+        {   
+			/// <inheritdoc/>
+			public override string DoThing() {}
+        }
+    }";
+			VerifyCSharpFix(test, fixtest);
+		}
+
+		protected override CodeFixProvider GetCSharpCodeFixProvider()
+		{
+			return new InsertInheritDocCodeFixProvider();
+		}
+	}
+}

--- a/PullThroughDoc/PullThroughDoc.Test/InterfaceDocumentationTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/InterfaceDocumentationTests.cs
@@ -36,18 +36,8 @@ namespace PullThroughDoc.Test
 			public string DoThing() {}
         }
     }";
-			var expected = new DiagnosticResult
-			{
-				Id = "PullThroughDoc",
-				Message = String.Format("Pull through documentation for {0}.", "DoThing"),
-				Severity = DiagnosticSeverity.Info,
-				Locations =
-					new[] {
-							new DiagnosticResultLocation("Test0.cs", 18, 18)
-						}
-			};
 
-			VerifyCSharpDiagnostic(test, expected);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 18, 18);
 
 			var fixtest = @"
     using System;
@@ -98,18 +88,8 @@ namespace PullThroughDoc.Test
 			public string DoThing(string param1) {}
         }
     }";
-			var expected = new DiagnosticResult
-			{
-				Id = "PullThroughDoc",
-				Message = String.Format("Pull through documentation for {0}.", "DoThing"),
-				Severity = DiagnosticSeverity.Info,
-				Locations =
-					new[] {
-							new DiagnosticResultLocation("Test0.cs", 20, 18)
-						}
-			};
 
-			VerifyCSharpDiagnostic(test, expected);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 20, 18);
 
 			var fixtest = @"
     using System;

--- a/PullThroughDoc/PullThroughDoc.Test/InterfaceDocumentationTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/InterfaceDocumentationTests.cs
@@ -19,13 +19,6 @@ namespace PullThroughDoc.Test
 		public void Interface_Documentation_PullsThrough()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		interface IInterface 
@@ -39,16 +32,9 @@ namespace PullThroughDoc.Test
         }
     }";
 
-			ExpectPullThroughDiagnosticAt(test, "DoThing", 18, 18);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 11, 18);
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		interface IInterface 
@@ -69,13 +55,6 @@ namespace PullThroughDoc.Test
 		public void Interface_MultiLineDocumentation_PullsThrough()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		interface IInterface 
@@ -91,16 +70,9 @@ namespace PullThroughDoc.Test
         }
     }";
 
-			ExpectPullThroughDiagnosticAt(test, "DoThing", 20, 18);
+			ExpectPullThroughDiagnosticAt(test, "DoThing", 13, 18);
 
 			var fixtest = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		interface IInterface 
@@ -125,13 +97,6 @@ namespace PullThroughDoc.Test
 		public void Interface_WithoutDocumentation_NoAnalyzer()
 		{
 			var test = @"
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-    using System.Diagnostics;
-
     namespace ConsoleApplication1
     {
 		interface IInterface 

--- a/PullThroughDoc/PullThroughDoc.Test/InterfaceDocumentationTests.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/InterfaceDocumentationTests.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using TestHelper;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PullThroughDoc.Test
 {
@@ -11,6 +8,11 @@ namespace PullThroughDoc.Test
 	[TestClass]
 	public class InterfaceDocumentationTests : PullThroughDocCodeFixVerifier
 	{
+		[TestInitialize]
+		public void Init()
+		{
+			CodeFixProvider = new PullThroughDocCodeFixProvider();
+		}
 
 		//Diagnostic and CodeFix both triggered and checked for
 		[TestMethod]

--- a/PullThroughDoc/PullThroughDoc.Test/PullThroughDoc.Test.csproj
+++ b/PullThroughDoc/PullThroughDoc.Test/PullThroughDoc.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PullThroughDoc/PullThroughDoc.Test/PullThroughDocCodeFixVerifier.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/PullThroughDocCodeFixVerifier.cs
@@ -8,6 +8,7 @@ namespace PullThroughDoc.Test
 {
 	public class PullThroughDocCodeFixVerifier : CodeFixVerifier
 	{
+		protected CodeFixProvider CodeFixProvider { get; set; }
 
 		protected void ExpectPullThroughDiagnosticAt(string text, string member, int line, int col)
 		{
@@ -27,7 +28,7 @@ namespace PullThroughDoc.Test
 
 		protected override CodeFixProvider GetCSharpCodeFixProvider()
 		{
-			return new PullThroughDocCodeFixProvider();
+			return CodeFixProvider;
 		}
 
 		protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/PullThroughDoc/PullThroughDoc.Test/PullThroughDocCodeFixVerifier.cs
+++ b/PullThroughDoc/PullThroughDoc.Test/PullThroughDocCodeFixVerifier.cs
@@ -1,11 +1,30 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
+using System;
 using TestHelper;
 
 namespace PullThroughDoc.Test
 {
 	public class PullThroughDocCodeFixVerifier : CodeFixVerifier
 	{
+
+		protected void ExpectPullThroughDiagnosticAt(string text, string member, int line, int col)
+		{
+			var expectedDiagnostic = new DiagnosticResult
+			{
+				Id = PullThroughDocAnalyzer.PullThroughDocDiagId,
+				Message = String.Format("Pull through documentation for {0}.", member),
+				Severity = DiagnosticSeverity.Info,
+				Locations =
+					new[] {
+							new DiagnosticResultLocation("Test0.cs", line, col)
+						}
+			};
+
+			VerifyCSharpDiagnostic(text, expectedDiagnostic);
+		}
+
 		protected override CodeFixProvider GetCSharpCodeFixProvider()
 		{
 			return new PullThroughDocCodeFixProvider();

--- a/PullThroughDoc/PullThroughDoc.Vsix/source.extension.vsixmanifest
+++ b/PullThroughDoc/PullThroughDoc.Vsix/source.extension.vsixmanifest
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="PullThroughDoc.85320641-1fcc-4f68-ad86-4b7046c2ec8d" Version="1.2" Language="en-US" Publisher="Dave W"/>
-        <DisplayName>Pull Through Documentation</DisplayName>
-        <Description xml:space="preserve">This analyzer allows you to pull through documentation from a base class or interface member for a method or property.</Description>
-        <MoreInfo>https://github.com/someguy20336/PullThroughDoc</MoreInfo>
-        <Icon>icon.png</Icon>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="PullThroughDoc" Path="|PullThroughDoc|"/>
-        <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="PullThroughDoc" Path="|PullThroughDoc|"/>
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-        <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,)" DisplayName="Roslyn Language Services" />
-    </Prerequisites>
+	<Metadata>
+		<Identity Id="PullThroughDoc.85320641-1fcc-4f68-ad86-4b7046c2ec8d" Version="1.3" Language="en-US" Publisher="Dave W"/>
+		<DisplayName>Pull Through Documentation</DisplayName>
+		<Description xml:space="preserve">This analyzer allows you to pull through documentation from a base class or interface member for a method or property.  It also gives the option to insert &lt;inheritdoc&gt;.</Description>
+		<MoreInfo>https://github.com/someguy20336/PullThroughDoc</MoreInfo>
+		<Icon>icon.png</Icon>
+	</Metadata>
+	<Installation>
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,)" />
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+	</Dependencies>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="PullThroughDoc" Path="|PullThroughDoc|"/>
+		<Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="PullThroughDoc" Path="|PullThroughDoc|"/>
+	</Assets>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+		<Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[15.0,)" DisplayName="Roslyn Language Services" />
+	</Prerequisites>
 </PackageManifest>

--- a/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
+++ b/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
@@ -4,7 +4,6 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,11 +12,6 @@ namespace PullThroughDoc
 {
 	public abstract class DocumentationCodeFixProviderBase : CodeFixProvider
 	{
-
-		public override ImmutableArray<string> FixableDiagnosticIds
-		{
-			get { return ImmutableArray.Create(PullThroughDocAnalyzer.PullThroughDocDiagId); }
-		}
 
 		public sealed override FixAllProvider GetFixAllProvider()
 		{

--- a/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
+++ b/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
@@ -14,9 +14,9 @@ namespace PullThroughDoc
 	{
 		protected abstract string Title { get; }
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
+		public override ImmutableArray<string> FixableDiagnosticIds
 		{
-			get { return ImmutableArray.Create(PullThroughDocAnalyzer.DiagnosticId); }
+			get { return ImmutableArray.Create(PullThroughDocAnalyzer.PullThroughDocDiagId); }
 		}
 
 		public sealed override FixAllProvider GetFixAllProvider()

--- a/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
+++ b/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PullThroughDoc
+{
+	public abstract class DocumentationCodeFixProviderBase : CodeFixProvider
+	{
+		protected abstract string Title { get; }
+
+		public sealed override ImmutableArray<string> FixableDiagnosticIds
+		{
+			get { return ImmutableArray.Create(PullThroughDocAnalyzer.DiagnosticId); }
+		}
+
+		public sealed override FixAllProvider GetFixAllProvider()
+		{
+			// See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+			return WellKnownFixAllProviders.BatchFixer;
+		}
+
+		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+		{
+			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			var diagnostic = context.Diagnostics.First();
+			var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+			// Find the type declaration identified by the diagnostic.
+			var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<MemberDeclarationSyntax>().First();
+
+			// Register a code action that will invoke the fix.
+			context.RegisterCodeFix(
+				CodeAction.Create(
+					title: Title,
+					createChangedDocument: c => Execute(context.Document, declaration, c),
+					equivalenceKey: Title),
+				diagnostic);
+		}
+
+		private async Task<Document> Execute(Document document, MemberDeclarationSyntax membDecl, CancellationToken cancellationToken)
+		{
+			// Get the symbol representing the type to be renamed.
+			var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+			var memberSymbol = semanticModel.GetDeclaredSymbol(membDecl, cancellationToken);
+
+			ISymbol overrideSymb = memberSymbol.GetBaseOrInterfaceMember();
+
+			if (overrideSymb == null)
+			{
+				return document;
+			}
+
+			if (overrideSymb.DeclaringSyntaxReferences.IsEmpty)
+			{
+				return document;
+			}
+
+			// Just use the first syntax reference because who cares at this point
+			var syntax = overrideSymb.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
+			IEnumerable<SyntaxTrivia> trivia = GetTriviaFromMember(syntax);
+			MemberDeclarationSyntax newMembDecl = membDecl.WithLeadingTrivia(trivia);
+
+			// Produce a new document
+			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
+			SyntaxNode other = root.ReplaceNode(membDecl, newMembDecl);
+			return document.WithSyntaxRoot(other);
+		}
+
+		protected abstract IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode baseMember);
+	}
+}

--- a/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
+++ b/PullThroughDoc/PullThroughDoc/DocumentationCodeFixProviderBase.cs
@@ -63,7 +63,7 @@ namespace PullThroughDoc
 
 			// Just use the first syntax reference because who cares at this point
 			var syntax = overrideSymb.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
-			IEnumerable<SyntaxTrivia> trivia = GetTriviaFromMember(syntax);
+			IEnumerable<SyntaxTrivia> trivia = GetTriviaFromMember(syntax, membDecl);
 			MemberDeclarationSyntax newMembDecl = membDecl.WithLeadingTrivia(trivia);
 
 			// Produce a new document
@@ -72,6 +72,6 @@ namespace PullThroughDoc
 			return document.WithSyntaxRoot(other);
 		}
 
-		protected abstract IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode baseMember);
+		protected abstract IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode baseMember, SyntaxNode targetMember);
 	}
 }

--- a/PullThroughDoc/PullThroughDoc/InsertInheritDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/InsertInheritDocCodeFixProvider.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 using System.Composition;
+using System.Linq;
 
 namespace PullThroughDoc
 {
@@ -13,35 +13,14 @@ namespace PullThroughDoc
 	{
 		protected override string Title => "Insert <inhericdoc />";
 
-		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode baseMember)
+		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode baseMember, SyntaxNode targetMember)
 		{
-            // https://stackoverflow.com/questions/41555962/how-to-add-xml-comments-to-a-methoddeclarationsyntax-node-using-roslyn
-            var trivia = SyntaxFactory.DocumentationCommentTrivia(
-                    SyntaxKind.SingleLineDocumentationCommentTrivia,
-                    SyntaxFactory.List<XmlNodeSyntax>(
-                        new XmlNodeSyntax[]{
-                            SyntaxFactory.XmlText()
-                            .WithTextTokens(
-                                SyntaxFactory.TokenList(
-                                    SyntaxFactory.XmlTextLiteral(
-                                        SyntaxFactory.TriviaList(
-                                            SyntaxFactory.DocumentationCommentExterior("///")),
-                                        " ",
-                                        " ",
-                                        SyntaxFactory.TriviaList()))),
-                            SyntaxFactory.XmlEmptyElement(SyntaxFactory.XmlName("inheritdoc")),
-                            SyntaxFactory.XmlText()
-                            .WithTextTokens(
-                                SyntaxFactory.TokenList(
-                                    SyntaxFactory.XmlTextNewLine(
-                                        SyntaxFactory.TriviaList(),
-                                        "\n",
-                                        "\n",
-                                        SyntaxFactory.TriviaList())))}));
-
-            // var text = SyntaxFactory.XmlText("/// <inheritdoc />");
-
-            return new[] { SyntaxFactory.Trivia(trivia) };
+            var leadingTrivia = targetMember.GetLeadingTrivia();
+            var triviaList = SyntaxFactory.ParseLeadingTrivia("/// <inheritdoc/>");
+            return leadingTrivia
+				.Concat(triviaList)
+				.Concat(new[] { SyntaxFactory.CarriageReturnLineFeed })
+				.Concat(leadingTrivia);
 		}
 	}
 }

--- a/PullThroughDoc/PullThroughDoc/InsertInheritDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/InsertInheritDocCodeFixProvider.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 
@@ -13,14 +14,21 @@ namespace PullThroughDoc
 	{
 		protected override string Title => "Insert <inhericdoc />";
 
+		public sealed override ImmutableArray<string> FixableDiagnosticIds
+		{
+			get { return ImmutableArray.Create(PullThroughDocAnalyzer.PullThroughDocDiagId, PullThroughDocAnalyzer.SwapToInheritDocId); }
+		}
+
 		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode baseMember, SyntaxNode targetMember)
 		{
             var leadingTrivia = targetMember.GetLeadingTrivia();
+			var indentWhitespace = leadingTrivia.Last();
+
             var triviaList = SyntaxFactory.ParseLeadingTrivia("/// <inheritdoc/>");
             return leadingTrivia
 				.Concat(triviaList)
-				.Concat(new[] { SyntaxFactory.CarriageReturnLineFeed })
-				.Concat(leadingTrivia);
+				.Concat(new [] { SyntaxFactory.CarriageReturnLineFeed })
+				.Concat(new[] { indentWhitespace });
 		}
 	}
 }

--- a/PullThroughDoc/PullThroughDoc/InsertInheritDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/InsertInheritDocCodeFixProvider.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Composition;
+
+namespace PullThroughDoc
+{
+
+	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(InsertInheritDocCodeFixProvider)), Shared]
+	public class InsertInheritDocCodeFixProvider : DocumentationCodeFixProviderBase
+	{
+		protected override string Title => "Insert <inhericdoc />";
+
+		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode baseMember)
+		{
+            // https://stackoverflow.com/questions/41555962/how-to-add-xml-comments-to-a-methoddeclarationsyntax-node-using-roslyn
+            var trivia = SyntaxFactory.DocumentationCommentTrivia(
+                    SyntaxKind.SingleLineDocumentationCommentTrivia,
+                    SyntaxFactory.List<XmlNodeSyntax>(
+                        new XmlNodeSyntax[]{
+                            SyntaxFactory.XmlText()
+                            .WithTextTokens(
+                                SyntaxFactory.TokenList(
+                                    SyntaxFactory.XmlTextLiteral(
+                                        SyntaxFactory.TriviaList(
+                                            SyntaxFactory.DocumentationCommentExterior("///")),
+                                        " ",
+                                        " ",
+                                        SyntaxFactory.TriviaList()))),
+                            SyntaxFactory.XmlEmptyElement(SyntaxFactory.XmlName("inheritdoc")),
+                            SyntaxFactory.XmlText()
+                            .WithTextTokens(
+                                SyntaxFactory.TokenList(
+                                    SyntaxFactory.XmlTextNewLine(
+                                        SyntaxFactory.TriviaList(),
+                                        "\n",
+                                        "\n",
+                                        SyntaxFactory.TriviaList())))}));
+
+            // var text = SyntaxFactory.XmlText("/// <inheritdoc />");
+
+            return new[] { SyntaxFactory.Trivia(trivia) };
+		}
+	}
+}

--- a/PullThroughDoc/PullThroughDoc/PullThroughDoc.csproj
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDoc.csproj
@@ -42,10 +42,4 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Xml.ReaderWriter">
-      <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.0.0\ref\netcoreapp2.0\System.Xml.ReaderWriter.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/PullThroughDoc/PullThroughDoc/PullThroughDoc.csproj
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDoc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -10,7 +10,6 @@
     <PackageId>PullThroughDoc</PackageId>
     <PackageVersion>1.0.0.0</PackageVersion>
     <Authors>dwhel</Authors>
-    <PackageLicenseUrl>http://LICENSE_URL_HERE_OR_DELETE_THIS_LINE</PackageLicenseUrl>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageIconUrl></PackageIconUrl>
     <RepositoryUrl>https://github.com/someguy20336/PullThroughDoc</RepositoryUrl>

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocAnalyzer.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocAnalyzer.cs
@@ -10,22 +10,30 @@ namespace PullThroughDoc
 	{
 		public const string PullThroughDocDiagId = "PullThroughDoc01";
 		public const string SwapToInheritDocId = "PullThroughDoc02";
+		public const string SwapToPullThroughDocId = "PullThroughDoc03";
+		private const string Category = "Design";
 
 		// You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
 		// See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
-		private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-		private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-		private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-		private const string Category = "Design";
+		private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.PullThroghDocTitle), Resources.ResourceManager, typeof(Resources));
+		private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.PullThroughDocMessageFormat), Resources.ResourceManager, typeof(Resources));
+		private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.PullThroughDocDescription), Resources.ResourceManager, typeof(Resources));
+		
 
 		private static DiagnosticDescriptor PullThroughDocRule 
 			= new DiagnosticDescriptor(PullThroughDocDiagId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
 
 		private static DiagnosticDescriptor SwapToInheritDocRule
-			= new DiagnosticDescriptor(SwapToInheritDocId, "Replace With <inheritdoc/>", MessageFormat, Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: Description);
+			= new DiagnosticDescriptor(SwapToInheritDocId, "Replace with <inheritdoc/>", "Replace with <inheritdoc/>", 
+				Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: Description);
+
+		private static DiagnosticDescriptor SwapToPullThroughDocRule
+			= new DiagnosticDescriptor(SwapToPullThroughDocId, "Replace with base <summary>", "Replace with base <summary>", 
+				Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: "Change to use the <summary> tag from the base class");
+
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics 
-			=> ImmutableArray.Create(PullThroughDocRule, SwapToInheritDocRule);
+			=> ImmutableArray.Create(PullThroughDocRule, SwapToInheritDocRule, SwapToPullThroughDocRule);
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -53,6 +61,10 @@ namespace PullThroughDoc
 				{
 					diagDesc = SwapToInheritDocRule;
 				}
+				else if (SuggestReplaceWithPullThroughDoc(currentDoc))
+				{
+					diagDesc = SwapToPullThroughDocRule;
+				}
 
 				if (diagDesc != null)
 				{
@@ -70,6 +82,11 @@ namespace PullThroughDoc
 		private static bool SuggestReplaceWithInheritDoc(string currentDoc)
 		{
 			return !string.IsNullOrEmpty(currentDoc) && !currentDoc.Contains("inheritdoc");
+		}
+
+		private static bool SuggestReplaceWithPullThroughDoc(string currentDoc)
+		{
+			return !string.IsNullOrEmpty(currentDoc) && currentDoc.Contains("inheritdoc");
 		}
 
 		private static bool TryGetBaseMemberDoc(SymbolAnalysisContext context, CancellationToken token, out string baseDoc)

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocAnalyzer.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocAnalyzer.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace PullThroughDoc
@@ -13,7 +8,8 @@ namespace PullThroughDoc
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
 	public class PullThroughDocAnalyzer : DiagnosticAnalyzer
 	{
-		public const string DiagnosticId = "PullThroughDoc";
+		public const string PullThroughDocDiagId = "PullThroughDoc01";
+		public const string SwapToInheritDocId = "PullThroughDoc02";
 
 		// You can change these strings in the Resources.resx file. If you do not want your analyzer to be localize-able, you can use regular strings for Title and MessageFormat.
 		// See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Localizing%20Analyzers.md for more on localization
@@ -22,9 +18,14 @@ namespace PullThroughDoc
 		private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AnalyzerDescription), Resources.ResourceManager, typeof(Resources));
 		private const string Category = "Design";
 
-		private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
+		private static DiagnosticDescriptor PullThroughDocRule 
+			= new DiagnosticDescriptor(PullThroughDocDiagId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
 
-		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+		private static DiagnosticDescriptor SwapToInheritDocRule
+			= new DiagnosticDescriptor(SwapToInheritDocId, "Replace With <inheritdoc/>", MessageFormat, Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: Description);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics 
+			=> ImmutableArray.Create(PullThroughDocRule, SwapToInheritDocRule);
 
 		public override void Initialize(AnalysisContext context)
 		{
@@ -37,30 +38,49 @@ namespace PullThroughDoc
 
 		private static void AnalyzeSymbol(SymbolAnalysisContext context)
 		{
-			// Check if we can pull through the doc
-			if (CanPullThroughDoc(context, context.CancellationToken))
-			{
-				var diagnostic = Diagnostic.Create(Rule, context.Symbol.Locations[0], context.Symbol.Name);
+			string currentDoc = context.Symbol.GetDocumentationCommentXml(cancellationToken: context.CancellationToken);
 
-				context.ReportDiagnostic(diagnostic);
+			// Check if we can pull through the doc
+			if (TryGetBaseMemberDoc(context, context.CancellationToken, out var baseDoc) && !string.IsNullOrEmpty(baseDoc))
+			{
+				DiagnosticDescriptor diagDesc = null;
+				if (SuggestPullThroughOrInherit(currentDoc))
+				{
+					diagDesc = PullThroughDocRule;
+					
+				}
+				else if (SuggestReplaceWithInheritDoc(currentDoc))
+				{
+					diagDesc = SwapToInheritDocRule;
+				}
+
+				if (diagDesc != null)
+				{
+					var diagnostic = Diagnostic.Create(diagDesc, context.Symbol.Locations[0], context.Symbol.Name);
+					context.ReportDiagnostic(diagnostic);
+				}
 			}
 		}
 
-		private static bool CanPullThroughDoc(SymbolAnalysisContext context, CancellationToken token)
+		private static bool SuggestPullThroughOrInherit(string currentDoc)
 		{
+			return string.IsNullOrEmpty(currentDoc);
+		}
+
+		private static bool SuggestReplaceWithInheritDoc(string currentDoc)
+		{
+			return !string.IsNullOrEmpty(currentDoc) && !currentDoc.Contains("inheritdoc");
+		}
+
+		private static bool TryGetBaseMemberDoc(SymbolAnalysisContext context, CancellationToken token, out string baseDoc)
+		{
+			baseDoc = null;
 			// The containing type isn't an interface
 			ISymbol symbol = context.Symbol;
 			INamedTypeSymbol containingType = symbol.ContainingType;
 			if (containingType.BaseType == null)
 			{
 				return false; // This is an interface
-			}
-
-			// Doesn't already have doc
-			string currentDoc = symbol.GetDocumentationCommentXml(cancellationToken: token);
-			if (!string.IsNullOrEmpty(currentDoc))
-			{
-				return false;
 			}
 
 			// Has a base symbol/interface method
@@ -77,8 +97,8 @@ namespace PullThroughDoc
 			}
 
 			// Base method has documentation
-			string baseDoc = baseSymbol.GetDocumentationCommentXml(cancellationToken: token);
-			return !string.IsNullOrEmpty(baseDoc);
+			baseDoc = baseSymbol.GetDocumentationCommentXml(cancellationToken: token);
+			return true;
 
 		}
 	}

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocAnalyzer.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocAnalyzer.cs
@@ -21,11 +21,12 @@ namespace PullThroughDoc
 		
 
 		private static DiagnosticDescriptor PullThroughDocRule 
-			= new DiagnosticDescriptor(PullThroughDocDiagId, Title, MessageFormat, Category, DiagnosticSeverity.Info, isEnabledByDefault: true, description: Description);
+			= new DiagnosticDescriptor(PullThroughDocDiagId, Title, MessageFormat, 
+				Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: Description);
 
 		private static DiagnosticDescriptor SwapToInheritDocRule
 			= new DiagnosticDescriptor(SwapToInheritDocId, "Replace with <inheritdoc/>", "Replace with <inheritdoc/>", 
-				Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: Description);
+				Category, DiagnosticSeverity.Hidden, isEnabledByDefault: true, description: "Replace <summary> with <inheritdoc>");
 
 		private static DiagnosticDescriptor SwapToPullThroughDocRule
 			= new DiagnosticDescriptor(SwapToPullThroughDocId, "Replace with base <summary>", "Replace with base <summary>", 

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
@@ -12,7 +12,7 @@ namespace PullThroughDoc
 	{
 		protected override string Title => "Pull Through Documentation";
 
-		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode syntax)
+		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode syntax, SyntaxNode targetMember)
 		{
 			// Remove regions
 			var nonRegion = syntax.GetLeadingTrivia().Where(tr => !tr.IsKind(SyntaxKind.RegionDirectiveTrivia)).ToList();

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
@@ -1,85 +1,18 @@
-using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Rename;
-using Microsoft.CodeAnalysis.Text;
 
 namespace PullThroughDoc
 {
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PullThroughDocCodeFixProvider)), Shared]
-	public class PullThroughDocCodeFixProvider : CodeFixProvider
+	public class PullThroughDocCodeFixProvider : DocumentationCodeFixProviderBase
 	{
-		private const string title = "Pull Through Documentation";
+		protected override string Title => "Pull Through Documentation";
 
-		public sealed override ImmutableArray<string> FixableDiagnosticIds
-		{
-			get { return ImmutableArray.Create(PullThroughDocAnalyzer.DiagnosticId); }
-		}
-
-		public sealed override FixAllProvider GetFixAllProvider()
-		{
-			// See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
-			return WellKnownFixAllProviders.BatchFixer;
-		}
-
-		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-			var diagnostic = context.Diagnostics.First();
-			var diagnosticSpan = diagnostic.Location.SourceSpan;
-
-			// Find the type declaration identified by the diagnostic.
-			var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<MemberDeclarationSyntax>().First();
-
-			// Register a code action that will invoke the fix.
-			context.RegisterCodeFix(
-				CodeAction.Create(
-					title: title,
-					createChangedDocument: c => PullThroughDocumentation(context.Document, declaration, c),
-					equivalenceKey: title),
-				diagnostic);
-		}
-
-		private async Task<Document> PullThroughDocumentation(Document document, MemberDeclarationSyntax membDecl, CancellationToken cancellationToken)
-		{
-
-			// Get the symbol representing the type to be renamed.
-			var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
-			var memberSymbol = semanticModel.GetDeclaredSymbol(membDecl, cancellationToken);
-
-			ISymbol overrideSymb = memberSymbol.GetBaseOrInterfaceMember();
-
-			if (overrideSymb == null)
-			{
-				return document;
-			}
-
-			if (overrideSymb.DeclaringSyntaxReferences.IsEmpty)
-			{
-				return document;
-			}
-
-			// Just use the first syntax reference because who cares at this point
-			var syntax = overrideSymb.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
-			var trivia = RemoveRegionsAndDuplicateWhitespace(syntax);
-			MemberDeclarationSyntax newMembDecl = membDecl.WithLeadingTrivia(trivia);
-
-			// Produce a new document
-			SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
-			SyntaxNode other = root.ReplaceNode(membDecl, newMembDecl);
-			return document.WithSyntaxRoot(other);
-		}
-
-		private IEnumerable<SyntaxTrivia> RemoveRegionsAndDuplicateWhitespace(SyntaxNode syntax)
+		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode syntax)
 		{
 			// Remove regions
 			var nonRegion = syntax.GetLeadingTrivia().Where(tr => !tr.IsKind(SyntaxKind.RegionDirectiveTrivia)).ToList();

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -10,7 +11,22 @@ namespace PullThroughDoc
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PullThroughDocCodeFixProvider)), Shared]
 	public class PullThroughDocCodeFixProvider : DocumentationCodeFixProviderBase
 	{
-		protected override string TitleForDiagnostic(string diagId) => "Pull Through Documentation";
+		public override ImmutableArray<string> FixableDiagnosticIds
+		{
+			get { return ImmutableArray.Create(PullThroughDocAnalyzer.PullThroughDocDiagId, PullThroughDocAnalyzer.SwapToPullThroughDocId); }
+		}
+
+		protected override string TitleForDiagnostic(string diagId)
+		{
+			switch (diagId)
+			{
+				case PullThroughDocAnalyzer.SwapToPullThroughDocId:
+					return "Change to <summary>";
+				case PullThroughDocAnalyzer.PullThroughDocDiagId:
+				default:
+					return "Pull Through Documentation";
+			}
+		}
 
 		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode syntax, SyntaxNode targetMember)
 		{

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
@@ -10,7 +10,7 @@ namespace PullThroughDoc
 	[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(PullThroughDocCodeFixProvider)), Shared]
 	public class PullThroughDocCodeFixProvider : DocumentationCodeFixProviderBase
 	{
-		protected override string Title => "Pull Through Documentation";
+		protected override string TitleForDiagnostic(string diagId) => "Pull Through Documentation";
 
 		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode syntax, SyntaxNode targetMember)
 		{
@@ -21,18 +21,7 @@ namespace PullThroughDoc
 				return nonRegion;
 			}
 
-			// Cut out duplicate whitespace trivia that might result from removing regions
-			var newList = new List<SyntaxTrivia>() { nonRegion[0] };
-			for (int i = 1; i < nonRegion.Count; i++)
-			{
-				bool isDoubleWhitespace = nonRegion[i - 1].Kind() == nonRegion[i].Kind() && nonRegion[i].IsKind(SyntaxKind.WhitespaceTrivia);
-				if (!isDoubleWhitespace)
-				{
-					newList.Add(nonRegion[i]);
-				}
-			}
-
-			return newList;
+			return CollapseWhitespace(nonRegion);
 		}
 	}
 }

--- a/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
+++ b/PullThroughDoc/PullThroughDoc/PullThroughDocCodeFixProvider.cs
@@ -30,14 +30,18 @@ namespace PullThroughDoc
 
 		protected override IEnumerable<SyntaxTrivia> GetTriviaFromMember(SyntaxNode syntax, SyntaxNode targetMember)
 		{
-			// Remove regions
-			var nonRegion = syntax.GetLeadingTrivia().Where(tr => !tr.IsKind(SyntaxKind.RegionDirectiveTrivia)).ToList();
-			if (nonRegion.Count == 0)
-			{
-				return nonRegion;
-			}
+			IEnumerable<SyntaxTrivia> leadingTrivia = targetMember.GetLeadingTrivia();
+			var indentWhitespace = leadingTrivia.Last();
+			leadingTrivia = CollapseWhitespace(leadingTrivia.Where(t => !t.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)));
 
-			return CollapseWhitespace(nonRegion);
+			// Grab only the doc comment trivia.  Seems to include a line break at the end
+			IEnumerable<SyntaxTrivia> nonRegion = syntax.GetLeadingTrivia()
+				.Where(tr => tr.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
+				.ToList();
+			
+			return leadingTrivia
+				.Concat(nonRegion)
+				.Concat(new[] { indentWhitespace });
 		}
 	}
 }

--- a/PullThroughDoc/PullThroughDoc/Resources.Designer.cs
+++ b/PullThroughDoc/PullThroughDoc/Resources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace PullThroughDoc {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace PullThroughDoc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -40,7 +39,7 @@ namespace PullThroughDoc {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PullThroughDoc.Resources", typeof(Resources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PullThroughDoc.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -62,29 +61,29 @@ namespace PullThroughDoc {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pull Through Documentation.
+        /// </summary>
+        internal static string PullThroghDocTitle {
+            get {
+                return ResourceManager.GetString("PullThroghDocTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Pull through the base class/interface documentation for a member..
         /// </summary>
-        internal static string AnalyzerDescription {
+        internal static string PullThroughDocDescription {
             get {
-                return ResourceManager.GetString("AnalyzerDescription", resourceCulture);
+                return ResourceManager.GetString("PullThroughDocDescription", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Pull through documentation for {0}..
         /// </summary>
-        internal static string AnalyzerMessageFormat {
+        internal static string PullThroughDocMessageFormat {
             get {
-                return ResourceManager.GetString("AnalyzerMessageFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Pull Through Documentation.
-        /// </summary>
-        internal static string AnalyzerTitle {
-            get {
-                return ResourceManager.GetString("AnalyzerTitle", resourceCulture);
+                return ResourceManager.GetString("PullThroughDocMessageFormat", resourceCulture);
             }
         }
     }

--- a/PullThroughDoc/PullThroughDoc/Resources.resx
+++ b/PullThroughDoc/PullThroughDoc/Resources.resx
@@ -117,16 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AnalyzerDescription" xml:space="preserve">
+  <data name="PullThroghDocTitle" xml:space="preserve">
+    <value>Pull Through Documentation</value>
+    <comment>The title of the diagnostic.</comment>
+  </data>
+  <data name="PullThroughDocDescription" xml:space="preserve">
     <value>Pull through the base class/interface documentation for a member.</value>
     <comment>An optional longer localizable description of the diagnostic.</comment>
   </data>
-  <data name="AnalyzerMessageFormat" xml:space="preserve">
+  <data name="PullThroughDocMessageFormat" xml:space="preserve">
     <value>Pull through documentation for {0}.</value>
     <comment>The format-able message the diagnostic displays.</comment>
-  </data>
-  <data name="AnalyzerTitle" xml:space="preserve">
-    <value>Pull Through Documentation</value>
-    <comment>The title of the diagnostic.</comment>
   </data>
 </root>


### PR DESCRIPTION
Implements #5 

- [x] Code fix provider for inserting `<inheritdoc/>` instead of pulling through
- [x] Unit Test for that ^
- [x] Code fix for swapping between inheritdoc and pulling through
- [x] Code keep some trivia when doing the `summary` one.  I am currently losing some new lines, it seems
- [x] Unit Test for that ^
- [x] Change pull through doc diagnostic severity to be a "hidden" instead of informational.  It is a little annoying to see in the info all the time

Ordering the code fixes?  I can't find any way that this is currently possible.